### PR TITLE
use system default SongTi font families

### DIFF
--- a/style.css
+++ b/style.css
@@ -12,3 +12,9 @@ pre {
 pre code {
   white-space: inherit;
 }
+
+.book.font-family-0 {
+  font-family: STSong, SimSun, serif;
+  font-weight: 400;
+  font-style: normal;
+}

--- a/style.css
+++ b/style.css
@@ -14,7 +14,7 @@ pre code {
 }
 
 .book.font-family-0 {
-  font-family: STSong, SimSun, serif;
+  font-family: "Source Han Serif SC", STSong, SimSun, serif;
   font-weight: 400;
   font-style: normal;
 }


### PR DESCRIPTION
重做PR #1 

这次仅改动了`style.css`. 请作者重新用bookdown编排。效果将会是，在gitbook输出中，选择`serif`字体时，文字将会以宋体呈现（此前为系统默认的黑体）。

STSong（华文宋体）在所有的苹果和绝大多数（安装了MS Office）的Windows系统上都有安装。还有少数没有安装华文宋体的Windows系统上，默认安装了SimSun宋体。

另外，上次我说的思源宋体，正是开源字体。也是Bookdown作者[谢益辉喜欢的和其中文博客中使用的字体](https://yihui.org/cn/2017/04/source-han-serif/). 不妨再考虑一下使用它？